### PR TITLE
Dont error when bags/ is absent

### DIFF
--- a/src/ft_perception_synthesis/CMakeLists.txt
+++ b/src/ft_perception_synthesis/CMakeLists.txt
@@ -22,7 +22,15 @@ endif()
 
 install(TARGETS perception
 	DESTINATION lib/${PROJECT_NAME})
-install(DIRECTORY launch config bags
+
+if (EXISTS bags)
+  install(DIRECTORY bags
+          DESTINATION share/${PROJECT_NAME})
+else()
+  message("Bags directory not found. Not installing. This may cause runtime errors!")
+endif()
+
+install(DIRECTORY launch config 
         DESTINATION share/${PROJECT_NAME})
 
 ament_package()


### PR DESCRIPTION
Only install bags when the directory is present. Otherwise, just emit a warning message.